### PR TITLE
Fix fall back to English when the selected plugin is no longer available

### DIFF
--- a/qml/KeyboardContainer.qml
+++ b/qml/KeyboardContainer.qml
@@ -127,6 +127,7 @@ Item {
 
             if (!maliit_input_method.languageIsSupported(language)) {
                 console.log("Language '" + language + "' not supported - using 'en' instead");
+                maliit_input_method.activeLanguage = "en";
                 language = "en";
             }
 


### PR DESCRIPTION
Backport fix to correctly fall back to the English plugin if a previously selected plugin has been uninstalled