### PR TITLE
Don't overwrite symbols, even if auto-correct is disabled

### DIFF
--- a/src/lib/models/text.cpp
+++ b/src/lib/models/text.cpp
@@ -109,8 +109,8 @@ void Text::commitPreedit()
     // we would expect the text editor to just update the surrounding text.
     // Raises the question whether we should have commitPreedit here at all,
     // but it does preserve some consistency at least.
-    m_surrounding = m_preedit;
-    m_surrounding_offset = m_preedit.length();
+    m_surrounding += m_preedit;
+    m_surrounding_offset += m_preedit.length();
     m_preedit.clear();
     m_primary_candidate.clear();
     m_face = PreeditDefault;

--- a/src/view/abstracttexteditor.cpp
+++ b/src/view/abstracttexteditor.cpp
@@ -408,8 +408,8 @@ void AbstractTextEditor::onKeyReleased(const Key &key)
                 }
                 alreadyAppended = true;
             }
-            else if (d->auto_correct_enabled && (isSeparator || isSymbol)) {
-                if(isSeparator && d->keyboardState == "CHARACTERS" && !email_detected) {
+            else if (isSeparator || isSymbol) {
+                if(d->auto_correct_enabled && isSeparator && d->keyboardState == "CHARACTERS" && !email_detected) {
                     // remove all whitespaces before the separator, then add a whitespace after it
                     removeTrailingWhitespaces();
                 }

--- a/src/view/abstracttexteditor.cpp
+++ b/src/view/abstracttexteditor.cpp
@@ -454,9 +454,10 @@ void AbstractTextEditor::onKeyReleased(const Key &key)
 
     case Key::ActionBackspace: {
         if (not d->backspace_sent) {
+            bool uncommittedDelete = d->text->preedit().isEmpty();
             singleBackspace();
             if (!email_detected) {
-                checkPreeditReentry(true);
+                checkPreeditReentry(uncommittedDelete);
             }
         } else if (!email_detected) {
             checkPreeditReentry(false);

--- a/tests/unittests/ut_editor/ut_editor.cpp
+++ b/tests/unittests/ut_editor/ut_editor.cpp
@@ -162,52 +162,76 @@ private:
     Q_SLOT void testAutoCaps_data()
     {
         QTest::addColumn<bool>("enable_auto_correct");
+        QTest::addColumn<bool>("enable_auto_caps");
         QTest::addColumn<QString>("input");
         QTest::addColumn<QString>("expected_commit_history");
         QTest::addColumn<int>("expected_auto_caps_activated_count");
 
-        QTest::newRow("auto-correct disabled, no punctation")
-                << false << "Helol Wordl " << "Helol Wordl " << 0;
+        QTest::newRow("auto-correct and autocaps disabled, no punctation")
+                << false << false << "Helol Wordl " << "Helol Wordl " << 0;
 //        QTest::newRow("auto-correct enabled, no punctation")
 //                << true << "Helol Wordl " << "Hello World " << 0;
-        QTest::newRow("auto-correct disabled, dot")
-                << false << "Helol Wordl. " << "Helol Wordl. " << 1;
+        QTest::newRow("auto-correct and autocaps disabled, dot")
+                << false << false << "Helol Wordl. " << "Helol Wordl. " << 0;
 //        QTest::newRow("auto-correct enabled, dot")
 //                << true << "Helol Wordl. " << "Hello World. " << 1;
-        QTest::newRow("auto-correct disabled, excalamation mark")
-                << false << "Helol Wordl! " << "Helol Wordl! " << 1;
+        QTest::newRow("auto-correct and autocaps disabled, excalamation mark")
+                << false << false << "Helol Wordl! " << "Helol Wordl! " << 0;
 //        QTest::newRow("auto-correct enabled, excalamation mark")
 //                << true << "Helol Wordl! " << "Hello World! " << 1;
-        QTest::newRow("auto-correct disabled, multiple dots")
-                << false << "Helol Wordl... " << "Helol Wordl... " << 1;
+        QTest::newRow("auto-correct and autocaps disabled, multiple dots")
+                << false << false << "Helol Wordl... " << "Helol Wordl... " << 0;
 //        QTest::newRow("auto-correct enabled, multiple dots")
 //                << true << "Helol Wordl... " << "Hello World... " << 1;
-        QTest::newRow("auto-correct disabled, comma")
-                << false << "Helol Wordl, " << "Helol Wordl, " << 0;
+        QTest::newRow("auto-correct and autocaps disabled, comma")
+                << false << false << "Helol Wordl, " << "Helol Wordl, " << 0;
 //        QTest::newRow("auto-correct enabled, comma")
 //                << true << "Helol Wordl, " << "Hello World, " << 0;
-        QTest::newRow("auto-correct disabled, quotation mark")
-                << false << "Helol Wordl\" " << "Helol Wordl\" " << 0;
+        QTest::newRow("auto-correct and autocaps disabled, quotation mark")
+                << false << false << "Helol Wordl\" " << "Helol Wordl\" " << 0;
 //        QTest::newRow("auto-correct enabled, quotation mark")
 //                << true << "Helol Wordl\" " << "Hello World\" " << 0;
-        QTest::newRow("auto-correct disabled, multiple sentences with mixed punctation")
-                << false << "This is a \"first sentence\". And a second, one! "
-                << "This is a \"first sentence\". And a second, one! " << 2;
-        QTest::newRow("auto-correct disabled, multiple sentences with dots")
-                << false << "First sentence. Second one. And Third. "
-                << "First sentence. Second one. And Third. " << 3;
+        QTest::newRow("auto-correct and autocaps disabled, multiple sentences with mixed punctation")
+                << false << false << "This is a \"first sentence\". And a second, one! "
+                << "This is a \"first sentence\". And a second, one! " << 0;
+        QTest::newRow("auto-correct and autocaps disabled, multiple sentences with dots")
+                << false << false << "First sentence. Second one. And Third. "
+                << "First sentence. Second one. And Third. " << 0;
+
+        QTest::newRow("auto-correct disabled, autocaps, no punctation")
+                << false << true << "Helol Wordl " << "Helol Wordl " << 0;
+        QTest::newRow("auto-correct disabled, autocaps, dot")
+                << false << true << "Helol Wordl. " << "Helol Wordl. " << 2;
+        QTest::newRow("auto-correct disabled, autocaps, excalamation mark")
+                << false << true << "Helol Wordl! " << "Helol Wordl! " << 2;
+        QTest::newRow("auto-correct disabled, autocaps, multiple dots")
+                << false << true << "Helol Wordl... " << "Helol Wordl... " << 4;
+        QTest::newRow("auto-correct disabled, autocaps, comma")
+                << false << true << "Helol Wordl, " << "Helol Wordl, " << 0;
+        QTest::newRow("auto-correct disabled, autocaps, quotation mark")
+                << false << true << "Helol Wordl\" " << "Helol Wordl\" " << 0;
+        QTest::newRow("auto-correct disabled, autocaps, multiple sentences with mixed punctation")
+                << false << true << "This is a \"first sentence\". And a second, one! "
+                << "This is a \"first sentence\". And a second, one! " << 4;
+        QTest::newRow("auto-correct disabled, autocaps, multiple sentences with dots")
+                << false << true << "First sentence. Second one. And Third. "
+                << "First sentence. Second one. And Third. " << 6;
 
         // Tests for the auto-correct and autocaps separator functionality
         // FIXME: In the current testing infra, we cannot really test this properly, as we are using the 'backspace' character
         //  a lot during auto-correction, which is currently not handled too well here.
-        QTest::newRow("auto-correct enabled, autocaps after separator auto-correction")
-                << true << "Hello Wor . This should be autocapsed "
+        QTest::newRow("auto-correct enabled, autocaps disabled, after separator auto-correction")
+                << true << false << "Hello Wor . This should be autocapsed "
+                << "Hello World . This should be autocapsed " << 0;
+        QTest::newRow("auto-correct and autocaps enabled, autocaps after separator auto-correction")
+                << true << true << "Hello Wor . This should be autocapsed "
                 << "Hello World . This should be autocapsed " << 2;
     }
 
     Q_SLOT void testAutoCaps()
     {
         QFETCH(bool, enable_auto_correct);
+        QFETCH(bool, enable_auto_caps);
         QFETCH(QString, input);
         QFETCH(QString, expected_commit_history);
         QFETCH(int, expected_auto_caps_activated_count);
@@ -225,7 +249,7 @@ private:
         editor.wordEngine()->setEnabled(true);
         editor.setAutoCorrectEnabled(enable_auto_correct);
         editor.setPreeditEnabled(true);
-        editor.setAutoCapsEnabled(true);
+        editor.setAutoCapsEnabled(enable_auto_caps);
 
         appendInput(&editor, input);
 

--- a/tests/unittests/ut_editor/ut_editor.cpp
+++ b/tests/unittests/ut_editor/ut_editor.cpp
@@ -257,6 +257,29 @@ private:
         Q_UNUSED(expected_auto_caps_activated_count)
         QCOMPARE(auto_caps_activated_spy.count(), expected_auto_caps_activated_count);
     }
+
+    Q_SLOT void testRegressionIssue2()
+    {
+        Logic::WordEngineProbe *word_engine = new Logic::WordEngineProbe;
+        Editor editor(EditorOptions(), new Model::Text, word_engine);
+        QSignalSpy auto_caps_activated_spy(&editor, SIGNAL(autoCapsActivated()));
+
+        InputMethodHostProbe host;
+        editor.setHost(&host);
+
+        initializeWordEngine(word_engine);
+
+        editor.wordEngine()->setWordPredictionEnabled(true);
+        editor.wordEngine()->setEnabled(true);
+        editor.setAutoCorrectEnabled(false);
+        editor.setPreeditEnabled(true);
+        editor.setAutoCapsEnabled(true);
+
+        appendInput(&editor, "Yesterday (th");
+        editor.replaceAndCommitPreedit("the");
+
+        QCOMPARE(host.commitStringHistory(), QString("Yesterday (the"));
+    }
 };
 
 QTEST_MAIN(TestEditor)

--- a/tests/unittests/ut_editor/wordengineprobe.cpp
+++ b/tests/unittests/ut_editor/wordengineprobe.cpp
@@ -63,6 +63,21 @@ bool MockLanguageFeatures::isSeparator(const QString &text) const
     return false;
 }
 
+bool MockLanguageFeatures::isSymbol(const QString &text) const
+{
+    static const QString symbols = QString::fromUtf8("#()[]");
+
+    if (text.isEmpty()) {
+        return false;
+    }
+
+    if (symbols.contains(text.right(1))) {
+        return true;
+    }
+
+    return false;
+}
+
 namespace MaliitKeyboard {
 namespace Logic {
 

--- a/tests/unittests/ut_editor/wordengineprobe.h
+++ b/tests/unittests/ut_editor/wordengineprobe.h
@@ -44,6 +44,7 @@ public:
     virtual ~MockLanguageFeatures() {}
 
     virtual bool isSeparator(const QString &text) const;
+    virtual bool isSymbol(const QString &text) const;
     virtual bool alwaysShowSuggestions() const { return false; }
     virtual bool autoCapsAvailable() const { return true; }
     virtual bool activateAutoCaps(const QString &preedit) const;


### PR DESCRIPTION
Fixes: https://github.com/ubports/keyboard-component/issues/2

Please don't merge this as-is: I want to add some tests. But I've built this in my [PPA](https://launchpad.net/~mardy/+archive/ubuntu/phablet) and it fixes my issue.