### PR TITLE
Update Keyboard_pt_url.qml

### DIFF
--- a/plugins/pt/qml/Keyboard_pt_url.qml
+++ b/plugins/pt/qml/Keyboard_pt_url.qml
@@ -84,7 +84,7 @@ KeyPad {
             SymbolShiftKey { id: symShiftKey;                            anchors.left: parent.left; height: parent.height; }
             LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
             CharKey        { id: slashKey; label: "/"; shifted: "/";     anchors.left: languageMenuButton.right; height: parent.height; }
-            UrlKey         { id: urlKey; label: ".com.br"; extended: [".com", ".pt", ".mz", ".ao", ".gw", ".tl"]; anchors.right: dotKey.left; height: parent.height; width: panel.keyWidth + units.gu(UI.emailLayoutUrlKeyPadding + 0.5); }
+            UrlKey         { id: urlKey; label: ".com"; extended: [".com.pt", ".pt", ".net", ".gov", ".org", ".edu"]; anchors.right: dotKey.left; height: parent.height; width: panel.keyWidth + units.gu(UI.emailLayoutUrlKeyPadding + 0.5); }
             CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?", "-", "_", "!", "+", "%","#","/"]; extendedShifted: ["?", "-", "_", "!", "+", "%","#","/"]; anchors.right: enterKey.left; height: parent.height; }
             ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
         }


### PR DESCRIPTION
This propose change is trying to reduce the annoyance reported in this bug: (https://bugs.launchpad.net/ubuntu-rtm/+source/indicator-keyboard/+bug/1424638) with the "com.br" (Brazil). In Portugal we use ".pt" or "com.pt". Aditionally, replaced some of the extended with most used urls in our country.