### PR TITLE
Update Keyboard_pt.qml Layout

### DIFF
--- a/plugins/pt/qml/Keyboard_pt.qml
+++ b/plugins/pt/qml/Keyboard_pt.qml
@@ -56,8 +56,7 @@ KeyPad {
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; }
-            CharKey { label: "ç"; shifted: "Ç"; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; rightSide: true; }
         }
 
         Row {


### PR DESCRIPTION
Hi,

Updated the layout of the keyboard to match the disposal of android and ios for our language. By long press the "C" key we get the "ç". We don't need a separate key for "Ç". I'll update the remain plugins also.

Thanks