### PR TITLE
Update Keyboard Portuguese (pt) Layout and URL extended key's

### DIFF
--- a/plugins/pt/qml/Keyboard_pt.qml
+++ b/plugins/pt/qml/Keyboard_pt.qml
@@ -56,8 +56,7 @@ KeyPad {
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; }
-            CharKey { label: "ç"; shifted: "Ç"; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; rightSide: true; }
         }
 
         Row {

--- a/plugins/pt/qml/Keyboard_pt_email.qml
+++ b/plugins/pt/qml/Keyboard_pt_email.qml
@@ -56,8 +56,7 @@ KeyPad {
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; }
-            CharKey { label: "ç"; shifted: "Ç"; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; rightSide: true; }
         }
 
         Row {
@@ -85,7 +84,7 @@ KeyPad {
             LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
             CharKey        { id: atKey;    label: "@"; shifted: "@";     anchors.left: languageMenuButton.right; height: parent.height; }
             SpaceKey       { id: spaceKey;                               anchors.left: atKey.right; anchors.right: urlKey.left; noMagnifier: true; height: parent.height; }
-            UrlKey         { id: urlKey; label: ".com.br"; extended: [".com", ".pt", ".mz", ".ao", ".gw", ".tl"]; anchors.right: dotKey.left; height: parent.height; width: panel.keyWidth + units.gu(UI.emailLayoutUrlKeyPadding + 0.5); }
+            UrlKey         { id: urlKey; label: ".com"; extended: [".pt", ".net", ".org", ".edu", ".gov", ".com.pt"]; anchors.right: dotKey.left; height: parent.height; }
             CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?", "-", "_", "!", "+", "%","#","/"]; extendedShifted: ["?", "-", "_", "!", "+", "%","#","/"]; anchors.right: enterKey.left; height: parent.height; }
             ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
         }

--- a/plugins/pt/qml/Keyboard_pt_url.qml
+++ b/plugins/pt/qml/Keyboard_pt_url.qml
@@ -56,8 +56,7 @@ KeyPad {
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; }
-            CharKey { label: "ç"; shifted: "Ç"; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; rightSide: true; }
         }
 
         Row {
@@ -84,7 +83,7 @@ KeyPad {
             SymbolShiftKey { id: symShiftKey;                            anchors.left: parent.left; height: parent.height; }
             LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
             CharKey        { id: slashKey; label: "/"; shifted: "/";     anchors.left: languageMenuButton.right; height: parent.height; }
-            UrlKey         { id: urlKey; label: ".com.br"; extended: [".com", ".pt", ".mz", ".ao", ".gw", ".tl"]; anchors.right: dotKey.left; height: parent.height; width: panel.keyWidth + units.gu(UI.emailLayoutUrlKeyPadding + 0.5); }
+            UrlKey         { id: urlKey; label: ".com"; extended: [".pt", ".net", ".org", ".edu", ".gov", ".com.pt"]; anchors.right: dotKey.left; height: parent.height; }
             CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?", "-", "_", "!", "+", "%","#","/"]; extendedShifted: ["?", "-", "_", "!", "+", "%","#","/"]; anchors.right: enterKey.left; height: parent.height; }
             ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
         }

--- a/plugins/pt/qml/Keyboard_pt_url_search.qml
+++ b/plugins/pt/qml/Keyboard_pt_url_search.qml
@@ -26,6 +26,7 @@ KeyPad {
     Column {
         id: c1
         anchors.fill: parent
+
         spacing: 0
 
         Row {
@@ -56,8 +57,7 @@ KeyPad {
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; }
-            CharKey { label: "ç"; shifted: "Ç"; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; rightSide: true; }
         }
 
         Row {
@@ -83,9 +83,9 @@ KeyPad {
 
             SymbolShiftKey { id: symShiftKey;                            anchors.left: parent.left; height: parent.height; }
             LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
-            CharKey        { id: slashKey; label: "/"; shifted: "/";     anchors.left: languageMenuButton.right; height: parent.height; }
+            CharKey        { id: slashKey;    label: "/"; shifted: "/";  anchors.left: languageMenuButton.right; height: parent.height; }
             SpaceKey       { id: spaceKey;                               anchors.left: slashKey.right; anchors.right: urlKey.left; noMagnifier: true; height: parent.height; }
-            UrlKey         { id: urlKey; label: ".com.br"; extended: [".com", ".pt", ".mz", ".ao", ".gw", ".tl"]; anchors.right: dotKey.left; height: parent.height; width: panel.keyWidth + units.gu(UI.emailLayoutUrlKeyPadding + 0.5); }
+            UrlKey         { id: urlKey; label: ".com"; extended: [".pt", ".net", ".org", ".edu", ".gov", ".com.pt"]; anchors.right: dotKey.left; height: parent.height; }
             CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?", "-", "_", "!", "+", "%","#","/"]; extendedShifted: ["?", "-", "_", "!", "+", "%","#","/"]; anchors.right: enterKey.left; height: parent.height; }
             ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
         }


### PR DESCRIPTION
Hi,

As the tittle says, this PR aims to update the Portuguese keyboard layout and URL extended key's. Since this plug in is about pt, it should serve the Portuguese people. Brazilians have to create a separate keyboard for them, since in our country we don't use ".br", this was already on the plan (https://bugs.launchpad.net/ubuntu/+source/ubuntu-keyboard/+bug/1380628).

Also this PR aims to update the layout to remove the separate key "Ç", since we can get this character by making a long press on "C" key, even android and iOS keyboard doesn't have it (see images attached). I think this also important because of Anbox, some users of android may one day want to try Ubuntu Touch and since they are used to a certain layout, we could provide it.

I made this modifications based on the ENG keyboard, just replaced with Portuguese characters. 
This is my first PR of this nature, so sorry for anything wrong.

Big thanks to Florian Leeber on the assistance.

![andord](https://user-images.githubusercontent.com/16002474/35053468-110f18ae-fba2-11e7-8939-7126ae8d691b.png)
![ioss](https://user-images.githubusercontent.com/16002474/35053470-1154d718-fba2-11e7-8ad3-64b26ed3b590.png)
![nexus 7 keyb](https://user-images.githubusercontent.com/16002474/35053471-11a25d4e-fba2-11e7-990c-cf888b64a4bd.png)


