### PR TITLE
 Work around keyboard being dismissed too often

### DIFF
--- a/qml/keys/PressArea.qml
+++ b/qml/keys/PressArea.qml
@@ -67,6 +67,12 @@ MultiPointTouchArea {
                         swipedOut = true;
                         cancelPress();
                     }
+                    
+                    // Dirty hack, see onReleased below
+                    if (point.y > panel.height) {
+                        // Touch point released past height of keyboard.
+                        return;
+                    }
 
                     var distance = point.y - lastY;
                     // If changing direction wait until movement passes 1 gu
@@ -76,17 +82,16 @@ MultiPointTouchArea {
                         lastY = point.y;
                         lastYChange = distance;
                     }
-                    // Hide if we get close to the bottom of the screen
+                    // Hide if we get close to the bottom of the screen.
                     // This works around issues with devices with touch buttons
                     // below the screen preventing release events when swiped
                     // over
-                    if(point.sceneY > fullScreenItem.height - units.gu(4) && point.y > startY + units.gu(8) && !held) {
+                    if(!held && point.sceneY > fullScreenItem.height - units.gu(4) && point.y > startY + units.gu(8)) {
                         maliit_input_method.hide();
                     }
                 } else {
                     lastY = point.y;
                 }
-                console.log(point.y)
             }
         }
     ]
@@ -132,13 +137,24 @@ MultiPointTouchArea {
     }
 
     onReleased: {
-        // Allow the user to swipe away the keyboard
-        if (point.y > startY + units.gu(8) && !held) {
-            maliit_input_method.hide();
-        } else {
-            bounceBackAnimation.from = keyboardSurface.y;
-            bounceBackAnimation.start();
+
+        // Don't evaluate if the release point is above the start point
+        // or further away from its start than the height of the whole keyboard.
+        // This works around touches sometimes being recognized as ending below
+        // the bottom of the screen.
+        if (point.y > panel.height) {
+            console.warn("Touch point released past height of keyboard. Ignoring.");
+        } else if (!(point.y <= startY)) {
+            // Handles swiping away the keyboard
+            // Hide if the end point is more than 8 grid units from the start
+            if (!held && point.y > startY + units.gu(8)) {
+                maliit_input_method.hide();
+            } else {
+                bounceBackAnimation.from = keyboardSurface.y;
+                bounceBackAnimation.start();
+            }
         }
+
         pressed = false;
         held = false;
         holdTimer.stop();

--- a/qml/keys/PressArea.qml
+++ b/qml/keys/PressArea.qml
@@ -86,6 +86,7 @@ MultiPointTouchArea {
                 } else {
                     lastY = point.y;
                 }
+                console.log(point.y)
             }
         }
     ]


### PR DESCRIPTION
Work done by @UniversalSuperBox

> For some reason, touch events are sometimes detected as ending tens to
hundreds of pixels away from their real end point. I suspect that this
is a problem with Mir and we won't really look into it until after we do
the work to upgrade Mir after OTA-4.
This works around the issue by ignoring touch events that occur far
below the possible area (ie, further than the height of the keyboard).
I've also changed the order of some evaluations to hopefully
short-circuit more often.

Fixes ubports/ubuntu-touch#567