### PR TITLE
Let ubuntu-keyboard-autopilot depend on autopilot-qt5 instead of liba…

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -92,7 +92,7 @@ Description: Ubuntu on-screen keyboard tests
 
 Package: ubuntu-keyboard-autopilot
 Architecture: all
-Depends: libautopilot-qt (>= 1.4),
+Depends: autopilot-qt5 (>= 1.4),
          ${misc:Depends},
          ${python:Depends},
          python3-evdev,


### PR DESCRIPTION
…utopilot-qt