### PR TITLE
autoCaps shouldn't be activated after ":"

### DIFF
--- a/plugins/westernsupport/westernlanguagefeatures.cpp
+++ b/plugins/westernsupport/westernlanguagefeatures.cpp
@@ -54,7 +54,7 @@ bool WesternLanguageFeatures::autoCapsAvailable() const
 
 bool WesternLanguageFeatures::activateAutoCaps(const QString &preedit) const
 {
-    static const QString sentenceBreak = QString::fromUtf8("!.?:\r\n");
+    static const QString sentenceBreak = QString::fromUtf8("!.?\r\n");
 
     if (preedit.isEmpty()) {
         return false;


### PR DESCRIPTION
this fixes #97 
as for ubports/crossbuilder#27 I opened this PR just to make CI building this and test. I'll remove the draft state once tested and confirmed it does what I expect
Thanks