### PR TITLE
Changed behavior of done button and double-tap

### DIFF
--- a/qml/FloatingActions.qml
+++ b/qml/FloatingActions.qml
@@ -62,11 +62,7 @@ RowLayout {
                 text: i18n.tr("Done")
                 iconName: "ok"
                 onTriggered: {
-                    if (cursorSwipeArea.selectionMode) {
-                        cursorSwipeArea.exitSelectionMode()
-                    } else {
-                        fullScreenItem.exitSwipeMode()
-                    }
+                    fullScreenItem.exitSwipeMode()
                 }
             }
     }

--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -348,7 +348,7 @@ Item {
                         verticalCenter: parent.verticalCenter
                     }
                     
-                    text: cursorSwipeArea.selectionMode ? i18n.tr("Swipe to move selection") 
+                    text: cursorSwipeArea.selectionMode ? i18n.tr("Swipe to move selection") + "\n\n" + i18n.tr("Double-tap to exit selection mode")
                                 : i18n.tr("Swipe to move cursor") + "\n\n" + i18n.tr("Double-tap to enter selection mode")
                 }
             }
@@ -407,8 +407,12 @@ Item {
                 var threshold = units.gu(2)
 
                 if (xReleaseDiff < threshold && yReleaseDiff < threshold) {
-                    cursorSwipeArea.selectionMode = true
-                    fullScreenItem.timerSwipe.stop()
+                    if (!cursorSwipeArea.selectionMode) {
+                        cursorSwipeArea.selectionMode = true
+                        fullScreenItem.timerSwipe.stop()
+                    } else {
+                        exitSelectionMode();
+                    }
                 }
                 
                 firstPress = Qt.point(0,0)


### PR DESCRIPTION
**Done** button will now fully exit the advanced function mode even coming from selection mode. No need to tap **Done** twice for exiting.

**Double-tapping** while in selection mode will now exit selection mode and back to cursor mover mode.


I'm still struggling on how to call all these modes :grinning: 