### PR TITLE
make extendedkey quickly usable

### DIFF
--- a/qml/keys/CharKey.qml
+++ b/qml/keys/CharKey.qml
@@ -338,7 +338,7 @@ Item {
 
     Timer {
         id: swipeTimer
-        interval: 750
+        interval: 150
         onTriggered: {
             swipeReady = true;
             keyMouseArea.evaluateSelectorSwipe();


### PR DESCRIPTION
For now , as a French, in order to use accents keys, i have to long press and wait 750ms to be able to select accent keys in ExtendedKeys overlay. Let try to reduce the timer so that i can quickly select the correct key.
 