### PR TITLE
Homogenic Layout for Catalan Keyboard

### DIFF
--- a/plugins/ca/qml/Keyboard_ca.qml
+++ b/plugins/ca/qml/Keyboard_ca.qml
@@ -34,13 +34,13 @@ KeyPad {
 
             CharKey { label: "q"; shifted: "Q"; extended: ["1"]; extendedShifted: ["1"]; leftSide: true; }
             CharKey { label: "w"; shifted: "W"; extended: ["2"]; extendedShifted: ["2"] }
-            CharKey { label: "e"; shifted: "E"; extended: ["3", "è", "é", "ê", "ë", "€"]; extendedShifted: ["3", "È","É", "Ê", "Ë", "€"] }
+            CharKey { label: "e"; shifted: "E"; extended: ["3","ê","è","é","ë","€"]; extendedShifted: ["3","Ê","È","É","Ë","€"] }
             CharKey { label: "r"; shifted: "R"; extended: ["4"]; extendedShifted: ["4"] }
-            CharKey { label: "t"; shifted: "T"; extended: ["5"]; extendedShifted: ["5"] }
+            CharKey { label: "t"; shifted: "T"; extended: ["5","'t","-te"]; extendedShifted: ["5","'T","-TE"] }
             CharKey { label: "y"; shifted: "Y"; extended: ["6"]; extendedShifted: ["6"] }
-            CharKey { label: "u"; shifted: "U"; extended: ["7", "û","ù","ú","ü"]; extendedShifted: ["7", "Û","Ù","Ú","Ü"] }
-            CharKey { label: "i"; shifted: "I"; extended: ["8", "î","ï","ì","í"]; extendedShifted: ["8", "Î","Ï","Ì","Í"] }
-            CharKey { label: "o"; shifted: "O"; extended: ["9", "ö","ô","ò","ó", "º","õ","œ"]; extendedShifted: ["9", "Ö","Ô","Ò","Ó", "º","Õ", "Œ"] }
+            CharKey { label: "u"; shifted: "U"; extended: ["7","û","ù","ú","ü"]; extendedShifted: ["7","Û","Ù","Ú","Ü"] }
+            CharKey { label: "i"; shifted: "I"; extended: ["8","î","ì","í","ï"]; extendedShifted: ["8","Î","Ì","Í","Ï"] }
+            CharKey { label: "o"; shifted: "O"; extended: ["9","õ","ô","ò","ó","ö","º","œ"]; extendedShifted: ["9","Õ","Ô","Ò","Ó","Ö","º","Œ"] }
             CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"]; rightSide: true; }
         }
 
@@ -48,15 +48,15 @@ KeyPad {
             anchors.horizontalCenter: parent.horizontalCenter;
             spacing: 0
 
-            CharKey { label: "a"; shifted: "A"; extended: ["ä","à","â","á","ã","å","ª","æ"]; extendedShifted: ["Ä","À","Â","Á","Ã","Å","ª","Æ"]; leftSide: true; }
-            CharKey { label: "s"; shifted: "S"; extended: ["ß","$"]; extendedShifted: ["ẞ","$"] }
+            CharKey { label: "a"; shifted: "A"; extended: ["à","å","ã","â","á","ä","ª","æ"]; extendedShifted: ["À","Å","Ã","Â","Á","Ä","ª","Æ"]; leftSide: true; }
+            CharKey { label: "s"; shifted: "S"; extended: ["'s","ß","-se","$"]; extendedShifted: ["'S","ẞ","-SE","$"] }
             CharKey { label: "d"; shifted: "D"; }
             CharKey { label: "f"; shifted: "F"; }
-            CharKey { label: "g"; shifted: "G"; }
-            CharKey { label: "h"; shifted: "H"; }
+            CharKey { label: "g"; shifted: "G"; extended: ["-"]; extendedShifted: ["-"] }
+            CharKey { label: "h"; shifted: "H"; extended: ["-hi","-ho"]; extendedShifted: ["-HI","-HO"] }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; extended: ["l·l"]; extendedShifted: ["L·L"] }
+            CharKey { label: "l"; shifted: "L"; extended: ["l·l","'l","-la","-lo"]; extendedShifted: ["L·L","'L","-LA","-LO"] }
             CharKey { label: "ç"; shifted: "Ç"; rightSide: true; }
         }
 
@@ -70,8 +70,8 @@ KeyPad {
             CharKey { label: "c"; shifted: "C"; extended: ["ç"]; extendedShifted: ["Ç"] }
             CharKey { label: "v"; shifted: "V"; }
             CharKey { label: "b"; shifted: "B"; }
-            CharKey { label: "n"; shifted: "N"; extended: ["ñ"]; extendedShifted: ["Ñ"] }
-            CharKey { label: "m"; shifted: "M"; }
+            CharKey { label: "n"; shifted: "N"; extended: ["ny","ñ"]; extendedShifted: ["NY","Ñ"] }
+            CharKey { label: "m"; shifted: "M"; extended: ["'m","-me"]; extendedShifted: ["'M","-ME"] }
             BackspaceKey {}
         }
 
@@ -83,9 +83,9 @@ KeyPad {
 
             SymbolShiftKey { id: symShiftKey;                            anchors.left: parent.left; height: parent.height; }
             LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
-            CharKey        { id: commaKey;    label: ","; shifted: ","; extended: ["'", "\"", ";", ":", "@", "&", "«","»", "(", ")"]; extendedShifted: ["'", "\"", ";", ":", "@", "&", "«","»", "(", ")"]; anchors.left: languageMenuButton.right; height: parent.height; }
+            CharKey        { id: commaKey;    label: ","; shifted: ","; extended: ["'","\"",";",":","@","«","»","(",")","&"]; extendedShifted: ["'","\"",";",":","@","«","»","(",")","&"]; anchors.left: languageMenuButton.right; height: parent.height; }
             SpaceKey       { id: spaceKey;                               anchors.left: commaKey.right; anchors.right: dotKey.left; noMagnifier: true; height: parent.height; }
-            CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?", "-", "_", "+", "%", "!", "#", "/", "·", "¿", "¡"];  extendedShifted: ["?", "-", "_", "+", "%", "!", "#", "/", "·", "¿", "¡"]; anchors.right: enterKey.left; height: parent.height; }
+            CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?","%","_","+","-","!","#","/","·","¿","¡"];  extendedShifted: ["?","%","_","+","-","!","#","/","·","¿","¡"]; anchors.right: enterKey.left; height: parent.height; }
             ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
         }
     } // column

--- a/plugins/ca/qml/Keyboard_ca.qml
+++ b/plugins/ca/qml/Keyboard_ca.qml
@@ -56,7 +56,7 @@ KeyPad {
             CharKey { label: "h"; shifted: "H"; extended: ["-hi","-ho"]; extendedShifted: ["-HI","-HO"] }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; extended: ["l·l","'l","-la","-lo"]; extendedShifted: ["L·L","'L","-LA","-LO"] }
+            CharKey { label: "l"; shifted: "L"; extended: ["l·l","'l","-li","-la","-lo"]; extendedShifted: ["L·L","'L","-LI","-LA","-LO"] }
             CharKey { label: "ç"; shifted: "Ç"; rightSide: true; }
         }
 
@@ -70,7 +70,7 @@ KeyPad {
             CharKey { label: "c"; shifted: "C"; extended: ["ç"]; extendedShifted: ["Ç"] }
             CharKey { label: "v"; shifted: "V"; }
             CharKey { label: "b"; shifted: "B"; }
-            CharKey { label: "n"; shifted: "N"; extended: ["ny","ñ"]; extendedShifted: ["NY","Ñ"] }
+            CharKey { label: "n"; shifted: "N"; extended: ["ny","'n","-ne","ñ"]; extendedShifted: ["NY","'N","-NE","Ñ"] }
             CharKey { label: "m"; shifted: "M"; extended: ["'m","-me"]; extendedShifted: ["'M","-ME"] }
             BackspaceKey {}
         }

--- a/plugins/ca/qml/Keyboard_ca.qml
+++ b/plugins/ca/qml/Keyboard_ca.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.9
 import keys 1.0
 
 KeyPad {

--- a/plugins/ca/qml/Keyboard_ca_email.qml
+++ b/plugins/ca/qml/Keyboard_ca_email.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.9
 import keys 1.0
 
 KeyPad {

--- a/plugins/ca/qml/Keyboard_ca_email.qml
+++ b/plugins/ca/qml/Keyboard_ca_email.qml
@@ -34,13 +34,13 @@ KeyPad {
 
             CharKey { label: "q"; shifted: "Q"; extended: ["1"]; extendedShifted: ["1"]; leftSide: true; }
             CharKey { label: "w"; shifted: "W"; extended: ["2"]; extendedShifted: ["2"] }
-            CharKey { label: "e"; shifted: "E"; extended: ["3"]; extendedShifted: ["3"] }
+            CharKey { label: "e"; shifted: "E"; extended: ["3","ê","è","é","ë","€"]; extendedShifted: ["3","Ê","È","É","Ë","€"] }
             CharKey { label: "r"; shifted: "R"; extended: ["4"]; extendedShifted: ["4"] }
             CharKey { label: "t"; shifted: "T"; extended: ["5"]; extendedShifted: ["5"] }
             CharKey { label: "y"; shifted: "Y"; extended: ["6"]; extendedShifted: ["6"] }
-            CharKey { label: "u"; shifted: "U"; extended: ["7"]; extendedShifted: ["7"] }
-            CharKey { label: "i"; shifted: "I"; extended: ["8"]; extendedShifted: ["8"] }
-            CharKey { label: "o"; shifted: "O"; extended: ["9"]; extendedShifted: ["9"] }
+            CharKey { label: "u"; shifted: "U"; extended: ["7","û","ù","ú","ü"]; extendedShifted: ["7","Û","Ù","Ú","Ü"] }
+            CharKey { label: "i"; shifted: "I"; extended: ["8","î","ì","í","ï"]; extendedShifted: ["8","Î","Ì","Í","Ï"] }
+            CharKey { label: "o"; shifted: "O"; extended: ["9","õ","ô","ò","ó","ö","º","œ"]; extendedShifted: ["9","Õ","Ô","Ò","Ó","Ö","º","Œ"] }
             CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"]; rightSide: true; }
         }
 
@@ -48,16 +48,16 @@ KeyPad {
             anchors.horizontalCenter: parent.horizontalCenter;
             spacing: 0
 
-            CharKey { label: "a"; shifted: "A"; leftSide: true; }
-            CharKey { label: "s"; shifted: "S"; extended: ["$"]; extendedShifted: ["$"] }
+            CharKey { label: "a"; shifted: "A"; extended: ["à","å","ã","â","á","ä","ª","æ"]; extendedShifted: ["À","Å","Ã","Â","Á","Ä","ª","Æ"]; leftSide: true; }
+            CharKey { label: "s"; shifted: "S"; extended: ["ß","$"]; extendedShifted: ["ẞ","$"] }
             CharKey { label: "d"; shifted: "D"; }
             CharKey { label: "f"; shifted: "F"; }
-            CharKey { label: "g"; shifted: "G"; }
+            CharKey { label: "g"; shifted: "G"; extended: ["-"]; extendedShifted: ["-"] }
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; }
-            CharKey { label: "-"; shifted: "-"; extended: ["_"];  extendedShifted: ["_"]; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; extended: ["l·l"]; extendedShifted: ["L·L"] }
+            CharKey { label: "-"; shifted: "-"; extended: ["_","ç"];  extendedShifted: ["_","Ç"]; rightSide: true; }
         }
 
         Row {
@@ -67,10 +67,10 @@ KeyPad {
             ShiftKey {}
             CharKey { label: "z"; shifted: "Z"; }
             CharKey { label: "x"; shifted: "X"; }
-            CharKey { label: "c"; shifted: "C"; }
+            CharKey { label: "c"; shifted: "C"; extended: ["ç"]; extendedShifted: ["Ç"] }
             CharKey { label: "v"; shifted: "V"; }
             CharKey { label: "b"; shifted: "B"; }
-            CharKey { label: "n"; shifted: "N"; }
+            CharKey { label: "n"; shifted: "N"; extended: ["ny","ñ"]; extendedShifted: ["NY","Ñ"] }
             CharKey { label: "m"; shifted: "M"; }
             BackspaceKey {}
         }

--- a/plugins/ca/qml/Keyboard_ca_email.qml
+++ b/plugins/ca/qml/Keyboard_ca_email.qml
@@ -34,13 +34,13 @@ KeyPad {
 
             CharKey { label: "q"; shifted: "Q"; extended: ["1"]; extendedShifted: ["1"]; leftSide: true; }
             CharKey { label: "w"; shifted: "W"; extended: ["2"]; extendedShifted: ["2"] }
-            CharKey { label: "e"; shifted: "E"; extended: ["3", "è", "é", "ê", "ë", "€"]; extendedShifted: ["3", "È","É", "Ê", "Ë", "€"] }
+            CharKey { label: "e"; shifted: "E"; extended: ["3"]; extendedShifted: ["3"] }
             CharKey { label: "r"; shifted: "R"; extended: ["4"]; extendedShifted: ["4"] }
             CharKey { label: "t"; shifted: "T"; extended: ["5"]; extendedShifted: ["5"] }
             CharKey { label: "y"; shifted: "Y"; extended: ["6"]; extendedShifted: ["6"] }
-            CharKey { label: "u"; shifted: "U"; extended: ["7", "û","ù","ú","ü"]; extendedShifted: ["7", "Û","Ù","Ú","Ü"] }
-            CharKey { label: "i"; shifted: "I"; extended: ["8", "î","ï","ì","í"]; extendedShifted: ["8", "Î","Ï","Ì","Í"] }
-            CharKey { label: "o"; shifted: "O"; extended: ["9", "ö","ô","ò","ó", "º","õ","œ"]; extendedShifted: ["9", "Ö","Ô","Ò","Ó", "º","Õ", "Œ"] }
+            CharKey { label: "u"; shifted: "U"; extended: ["7"]; extendedShifted: ["7"] }
+            CharKey { label: "i"; shifted: "I"; extended: ["8"]; extendedShifted: ["8"] }
+            CharKey { label: "o"; shifted: "O"; extended: ["9"]; extendedShifted: ["9"] }
             CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"]; rightSide: true; }
         }
 
@@ -48,16 +48,16 @@ KeyPad {
             anchors.horizontalCenter: parent.horizontalCenter;
             spacing: 0
 
-            CharKey { label: "a"; shifted: "A"; extended: ["ä","à","â","á","ã","å","ª","æ"]; extendedShifted: ["Ä","À","Â","Á","Ã","Å","ª","Æ"]; leftSide: true; }
-            CharKey { label: "s"; shifted: "S"; extended: ["ß","$"]; extendedShifted: ["ẞ","$"] }
+            CharKey { label: "a"; shifted: "A"; leftSide: true; }
+            CharKey { label: "s"; shifted: "S"; extended: ["$"]; extendedShifted: ["$"] }
             CharKey { label: "d"; shifted: "D"; }
             CharKey { label: "f"; shifted: "F"; }
             CharKey { label: "g"; shifted: "G"; }
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; extended: ["l·l"]; extendedShifted: ["L·L"] }
-            CharKey { label: "ç"; shifted: "Ç"; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; }
+            CharKey { label: "-"; shifted: "-"; extended: ["_"];  extendedShifted: ["_"]; rightSide: true; }
         }
 
         Row {
@@ -67,10 +67,10 @@ KeyPad {
             ShiftKey {}
             CharKey { label: "z"; shifted: "Z"; }
             CharKey { label: "x"; shifted: "X"; }
-            CharKey { label: "c"; shifted: "C"; extended: ["ç"]; extendedShifted: ["Ç"] }
+            CharKey { label: "c"; shifted: "C"; }
             CharKey { label: "v"; shifted: "V"; }
             CharKey { label: "b"; shifted: "B"; }
-            CharKey { label: "n"; shifted: "N"; extended: ["ñ"]; extendedShifted: ["Ñ"] }
+            CharKey { label: "n"; shifted: "N"; }
             CharKey { label: "m"; shifted: "M"; }
             BackspaceKey {}
         }
@@ -86,7 +86,7 @@ KeyPad {
             CharKey        { id: atKey;    label: "@"; shifted: "@";     anchors.left: languageMenuButton.right; height: parent.height; }
             SpaceKey       { id: spaceKey;                               anchors.left: atKey.right; anchors.right: urlKey.left; noMagnifier: true; height: parent.height; }
             UrlKey         { id: urlKey; label: ".com"; extended: [".cat", ".ad", ".es"]; anchors.right: dotKey.left; height: parent.height; }
-            CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?", "-", "_", "+", "%", "!", "#", "/", "·", "¿", "¡"];  extendedShifted: ["?", "-", "_", "+", "%", "!", "#", "/", "·", "¿", "¡"]; anchors.right: enterKey.left; height: parent.height; }
+            CharKey        { id: dotKey;      label: "."; shifted: "."; anchors.right: enterKey.left; height: parent.height; }
             ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
         }
     } // column

--- a/plugins/ca/qml/Keyboard_ca_url.qml
+++ b/plugins/ca/qml/Keyboard_ca_url.qml
@@ -34,13 +34,13 @@ KeyPad {
 
             CharKey { label: "q"; shifted: "Q"; extended: ["1"]; extendedShifted: ["1"]; leftSide: true; }
             CharKey { label: "w"; shifted: "W"; extended: ["2"]; extendedShifted: ["2"] }
-            CharKey { label: "e"; shifted: "E"; extended: ["3", "è", "é", "ê", "ë", "€"]; extendedShifted: ["3", "È","É", "Ê", "Ë", "€"] }
+            CharKey { label: "e"; shifted: "E"; extended: ["3"]; extendedShifted: ["3"] }
             CharKey { label: "r"; shifted: "R"; extended: ["4"]; extendedShifted: ["4"] }
             CharKey { label: "t"; shifted: "T"; extended: ["5"]; extendedShifted: ["5"] }
             CharKey { label: "y"; shifted: "Y"; extended: ["6"]; extendedShifted: ["6"] }
-            CharKey { label: "u"; shifted: "U"; extended: ["7", "û","ù","ú","ü"]; extendedShifted: ["7", "Û","Ù","Ú","Ü"] }
-            CharKey { label: "i"; shifted: "I"; extended: ["8", "î","ï","ì","í"]; extendedShifted: ["8", "Î","Ï","Ì","Í"] }
-            CharKey { label: "o"; shifted: "O"; extended: ["9", "ö","ô","ò","ó", "º","õ","œ"]; extendedShifted: ["9", "Ö","Ô","Ò","Ó", "º","Õ", "Œ"] }
+            CharKey { label: "u"; shifted: "U"; extended: ["7"]; extendedShifted: ["7"] }
+            CharKey { label: "i"; shifted: "I"; extended: ["8"]; extendedShifted: ["8"] }
+            CharKey { label: "o"; shifted: "O"; extended: ["9"]; extendedShifted: ["9"] }
             CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"]; rightSide: true; }
         }
 
@@ -48,16 +48,16 @@ KeyPad {
             anchors.horizontalCenter: parent.horizontalCenter;
             spacing: 0
 
-            CharKey { label: "a"; shifted: "A"; extended: ["ä","à","â","á","ã","å","ª","æ"]; extendedShifted: ["Ä","À","Â","Á","Ã","Å","ª","Æ"]; leftSide: true; }
-            CharKey { label: "s"; shifted: "S"; extended: ["ß","$"]; extendedShifted: ["ẞ","$"] }
+            CharKey { label: "a"; shifted: "A"; leftSide: true; }
+            CharKey { label: "s"; shifted: "S"; }
             CharKey { label: "d"; shifted: "D"; }
             CharKey { label: "f"; shifted: "F"; }
             CharKey { label: "g"; shifted: "G"; }
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; extended: ["l·l"]; extendedShifted: ["L·L"] }
-            CharKey { label: "ç"; shifted: "Ç"; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; }
+            CharKey { label: "-"; shifted: "-"; extended: ["_"];  extendedShifted: ["_"]; rightSide: true; }
         }
 
         Row {
@@ -67,10 +67,10 @@ KeyPad {
             ShiftKey {}
             CharKey { label: "z"; shifted: "Z"; }
             CharKey { label: "x"; shifted: "X"; }
-            CharKey { label: "c"; shifted: "C"; extended: ["ç"]; extendedShifted: ["Ç"] }
+            CharKey { label: "c"; shifted: "C"; }
             CharKey { label: "v"; shifted: "V"; }
             CharKey { label: "b"; shifted: "B"; }
-            CharKey { label: "n"; shifted: "N"; extended: ["ñ"]; extendedShifted: ["Ñ"] }
+            CharKey { label: "n"; shifted: "N"; }
             CharKey { label: "m"; shifted: "M"; }
             BackspaceKey {}
         }
@@ -85,7 +85,7 @@ KeyPad {
             LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
             CharKey        { id: slashKey; label: "/"; shifted: "/";     anchors.left: languageMenuButton.right; height: parent.height; }
             UrlKey         { id: urlKey; label: ".com"; extended: [".cat", ".ad", ".es"]; anchors.right: dotKey.left; height: parent.height; }
-            CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?", "-", "_", "+", "%", "!", "#", "/", "·", "¿", "¡"];  extendedShifted: ["?", "-", "_", "+", "%", "!", "#", "/", "·", "¿", "¡"]; anchors.right: enterKey.left; height: parent.height; }
+            CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?","+","%","#","!"];  extendedShifted: ["?","+","%","#","!"]; anchors.right: enterKey.left; height: parent.height; }
             ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
         }
     } // column

--- a/plugins/ca/qml/Keyboard_ca_url.qml
+++ b/plugins/ca/qml/Keyboard_ca_url.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.9
 import keys 1.0
 
 KeyPad {

--- a/plugins/ca/qml/Keyboard_ca_url_search.qml
+++ b/plugins/ca/qml/Keyboard_ca_url_search.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.9
 import keys 1.0
 
 KeyPad {

--- a/plugins/ca/qml/Keyboard_ca_url_search.qml
+++ b/plugins/ca/qml/Keyboard_ca_url_search.qml
@@ -34,13 +34,13 @@ KeyPad {
 
             CharKey { label: "q"; shifted: "Q"; extended: ["1"]; extendedShifted: ["1"]; leftSide: true; }
             CharKey { label: "w"; shifted: "W"; extended: ["2"]; extendedShifted: ["2"] }
-            CharKey { label: "e"; shifted: "E"; extended: ["3"]; extendedShifted: ["3"] }
+            CharKey { label: "e"; shifted: "E"; extended: ["3","ê","è","é","ë","€"]; extendedShifted: ["3","Ê","È","É","Ë","€"] }
             CharKey { label: "r"; shifted: "R"; extended: ["4"]; extendedShifted: ["4"] }
-            CharKey { label: "t"; shifted: "T"; extended: ["5"]; extendedShifted: ["5"] }
+            CharKey { label: "t"; shifted: "T"; extended: ["5","'t","-te"]; extendedShifted: ["5","'T","-TE"] }
             CharKey { label: "y"; shifted: "Y"; extended: ["6"]; extendedShifted: ["6"] }
-            CharKey { label: "u"; shifted: "U"; extended: ["7"]; extendedShifted: ["7"] }
-            CharKey { label: "i"; shifted: "I"; extended: ["8"]; extendedShifted: ["8"] }
-            CharKey { label: "o"; shifted: "O"; extended: ["9"]; extendedShifted: ["9"] }
+            CharKey { label: "u"; shifted: "U"; extended: ["7","û","ù","ú","ü"]; extendedShifted: ["7","Û","Ù","Ú","Ü"] }
+            CharKey { label: "i"; shifted: "I"; extended: ["8","î","ì","í","ï"]; extendedShifted: ["8","Î","Ì","Í","Ï"] }
+            CharKey { label: "o"; shifted: "O"; extended: ["9","õ","ô","ò","ó","ö","º","œ"]; extendedShifted: ["9","Õ","Ô","Ò","Ó","Ö","º","Œ"] }
             CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"]; rightSide: true; }
         }
 
@@ -48,16 +48,16 @@ KeyPad {
             anchors.horizontalCenter: parent.horizontalCenter;
             spacing: 0
 
-            CharKey { label: "a"; shifted: "A"; leftSide: true; }
-            CharKey { label: "s"; shifted: "S"; }
+            CharKey { label: "a"; shifted: "A"; extended: ["à","å","ã","â","á","ä","ª","æ"]; extendedShifted: ["À","Å","Ã","Â","Á","Ä","ª","Æ"]; leftSide: true; }
+            CharKey { label: "s"; shifted: "S"; extended: ["'s","ß","-se","$"]; extendedShifted: ["'S","ẞ","-SE","$"] }
             CharKey { label: "d"; shifted: "D"; }
             CharKey { label: "f"; shifted: "F"; }
-            CharKey { label: "g"; shifted: "G"; }
-            CharKey { label: "h"; shifted: "H"; }
+            CharKey { label: "g"; shifted: "G"; extended: ["-"]; extendedShifted: ["-"] }
+            CharKey { label: "h"; shifted: "H"; extended: ["-hi","-ho"]; extendedShifted: ["-HI","-HO"] }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; }
-            CharKey { label: "-"; shifted: "-"; extended: ["_"];  extendedShifted: ["_"]; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; extended: ["l·l","'l","-li","-la","-lo"]; extendedShifted: ["L·L","'L","-LI","-LA","-LO"] }
+            CharKey { label: "ç"; shifted: "Ç"; rightSide: true; }
         }
 
         Row {
@@ -67,11 +67,11 @@ KeyPad {
             ShiftKey {}
             CharKey { label: "z"; shifted: "Z"; }
             CharKey { label: "x"; shifted: "X"; }
-            CharKey { label: "c"; shifted: "C"; }
+            CharKey { label: "c"; shifted: "C"; extended: ["ç"]; extendedShifted: ["Ç"] }
             CharKey { label: "v"; shifted: "V"; }
             CharKey { label: "b"; shifted: "B"; }
-            CharKey { label: "n"; shifted: "N"; }
-            CharKey { label: "m"; shifted: "M"; }
+            CharKey { label: "n"; shifted: "N"; extended: ["ny","'n","-ne","ñ"]; extendedShifted: ["NY","'N","-NE","Ñ"] }
+            CharKey { label: "m"; shifted: "M"; extended: ["'m","-me"]; extendedShifted: ["'M","-ME"] }
             BackspaceKey {}
         }
 
@@ -86,7 +86,7 @@ KeyPad {
             CharKey        { id: slashKey; label: "/"; shifted: "/";     anchors.left: languageMenuButton.right; height: parent.height; }
             SpaceKey       { id: spaceKey;                               anchors.left: slashKey.right; anchors.right: urlKey.left; noMagnifier: true; height: parent.height; }
             UrlKey         { id: urlKey; label: ".com"; extended: [".cat", ".ad", ".es"]; anchors.right: dotKey.left; height: parent.height; }
-            CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?","+","%","#","!"];  extendedShifted: ["?","+","%","#","!"]; anchors.right: enterKey.left; height: parent.height; }
+            CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?","+","%","_","-","#","!"];  extendedShifted: ["?","+","%","_","-","#","!"]; anchors.right: enterKey.left; height: parent.height; }
             ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
         }
     } // column

--- a/plugins/ca/qml/Keyboard_ca_url_search.qml
+++ b/plugins/ca/qml/Keyboard_ca_url_search.qml
@@ -34,13 +34,13 @@ KeyPad {
 
             CharKey { label: "q"; shifted: "Q"; extended: ["1"]; extendedShifted: ["1"]; leftSide: true; }
             CharKey { label: "w"; shifted: "W"; extended: ["2"]; extendedShifted: ["2"] }
-            CharKey { label: "e"; shifted: "E"; extended: ["3", "è", "é", "ê", "ë", "€"]; extendedShifted: ["3", "È","É", "Ê", "Ë", "€"] }
+            CharKey { label: "e"; shifted: "E"; extended: ["3"]; extendedShifted: ["3"] }
             CharKey { label: "r"; shifted: "R"; extended: ["4"]; extendedShifted: ["4"] }
             CharKey { label: "t"; shifted: "T"; extended: ["5"]; extendedShifted: ["5"] }
             CharKey { label: "y"; shifted: "Y"; extended: ["6"]; extendedShifted: ["6"] }
-            CharKey { label: "u"; shifted: "U"; extended: ["7", "û","ù","ú","ü"]; extendedShifted: ["7", "Û","Ù","Ú","Ü"] }
-            CharKey { label: "i"; shifted: "I"; extended: ["8", "î","ï","ì","í"]; extendedShifted: ["8", "Î","Ï","Ì","Í"] }
-            CharKey { label: "o"; shifted: "O"; extended: ["9", "ö","ô","ò","ó", "º","õ","œ"]; extendedShifted: ["9", "Ö","Ô","Ò","Ó", "º","Õ", "Œ"] }
+            CharKey { label: "u"; shifted: "U"; extended: ["7"]; extendedShifted: ["7"] }
+            CharKey { label: "i"; shifted: "I"; extended: ["8"]; extendedShifted: ["8"] }
+            CharKey { label: "o"; shifted: "O"; extended: ["9"]; extendedShifted: ["9"] }
             CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"]; rightSide: true; }
         }
 
@@ -48,16 +48,16 @@ KeyPad {
             anchors.horizontalCenter: parent.horizontalCenter;
             spacing: 0
 
-            CharKey { label: "a"; shifted: "A"; extended: ["ä","à","â","á","ã","å","ª","æ"]; extendedShifted: ["Ä","À","Â","Á","Ã","Å","ª","Æ"]; leftSide: true; }
-            CharKey { label: "s"; shifted: "S"; extended: ["ß","$"]; extendedShifted: ["ẞ","$"] }
+            CharKey { label: "a"; shifted: "A"; leftSide: true; }
+            CharKey { label: "s"; shifted: "S"; }
             CharKey { label: "d"; shifted: "D"; }
             CharKey { label: "f"; shifted: "F"; }
             CharKey { label: "g"; shifted: "G"; }
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; extended: ["l·l"]; extendedShifted: ["L·L"] }
-            CharKey { label: "ç"; shifted: "Ç"; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; }
+            CharKey { label: "-"; shifted: "-"; extended: ["_"];  extendedShifted: ["_"]; rightSide: true; }
         }
 
         Row {
@@ -67,10 +67,10 @@ KeyPad {
             ShiftKey {}
             CharKey { label: "z"; shifted: "Z"; }
             CharKey { label: "x"; shifted: "X"; }
-            CharKey { label: "c"; shifted: "C"; extended: ["ç"]; extendedShifted: ["Ç"] }
+            CharKey { label: "c"; shifted: "C"; }
             CharKey { label: "v"; shifted: "V"; }
             CharKey { label: "b"; shifted: "B"; }
-            CharKey { label: "n"; shifted: "N"; extended: ["ñ"]; extendedShifted: ["Ñ"] }
+            CharKey { label: "n"; shifted: "N"; }
             CharKey { label: "m"; shifted: "M"; }
             BackspaceKey {}
         }
@@ -86,7 +86,7 @@ KeyPad {
             CharKey        { id: slashKey; label: "/"; shifted: "/";     anchors.left: languageMenuButton.right; height: parent.height; }
             SpaceKey       { id: spaceKey;                               anchors.left: slashKey.right; anchors.right: urlKey.left; noMagnifier: true; height: parent.height; }
             UrlKey         { id: urlKey; label: ".com"; extended: [".cat", ".ad", ".es"]; anchors.right: dotKey.left; height: parent.height; }
-            CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?", "-", "_", "+", "%", "!", "#", "/", "·", "¿", "¡"];  extendedShifted: ["?", "-", "_", "+", "%", "!", "#", "/", "·", "¿", "¡"]; anchors.right: enterKey.left; height: parent.height; }
+            CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?","+","%","#","!"];  extendedShifted: ["?","+","%","#","!"]; anchors.right: enterKey.left; height: parent.height; }
             ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
         }
     } // column


### PR DESCRIPTION
fixes https://github.com/ubports/keyboard-component/issues/125

- Reordered accented vowels to be all displayed in a similar manner
- Added common pronoun particles (pronoms febles) for speed typing
- Added Catalan graphical symbols
- Removed non url and email character from url and email layouts

Before / after
![imatge](https://user-images.githubusercontent.com/6640041/79674129-86a77400-81e0-11ea-88eb-2a0d8413c801.png)

![imatge](https://user-images.githubusercontent.com/6640041/79674108-71cae080-81e0-11ea-83c5-864744279b62.png)

![imatge](https://user-images.githubusercontent.com/6640041/79674114-7abbb200-81e0-11ea-950b-08d02f1c607e.png)

![imatge](https://user-images.githubusercontent.com/6640041/79674116-7ee7cf80-81e0-11ea-82d2-d9006fcdc341.png)

![imatge](https://user-images.githubusercontent.com/6640041/79674140-93c46300-81e0-11ea-874d-3797a356ed27.png)

Added sound symbols...

![imatge](https://user-images.githubusercontent.com/6640041/79794807-37ce1b80-8353-11ea-99d8-b1ce7eb211f0.png)

and speed typing (pronoms febles):

![imatge](https://user-images.githubusercontent.com/6640041/79674163-be162080-81e0-11ea-9396-09b0631bcffc.png)

![imatge](https://user-images.githubusercontent.com/6640041/79674167-c66e5b80-81e0-11ea-8b12-a8d795f8cd28.png)

![imatge](https://user-images.githubusercontent.com/6640041/79794877-5207f980-8353-11ea-9ade-392a509bc013.png)

Reordered other symbols (closer the most commons, farther the less common):

![imatge](https://user-images.githubusercontent.com/6640041/79674184-e00fa300-81e0-11ea-8381-fb9b5725b049.png)

![imatge](https://user-images.githubusercontent.com/6640041/79674190-e6058400-81e0-11ea-8ab3-12fde42bfe76.png)

Also I have modified email and url keyboards, leaving only accepted characters but left them for url_search