### PR TITLE
Add a Thai keyboard without prediction support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -475,6 +475,14 @@ Depends: ubuntu-keyboard (= ${binary:Version}),
 Description: Ubuntu on-screen keyboard data files - Swiss French
  Data files for the Ubuntu virtual keyboard - Swiss French
 
+Package: ubuntu-keyboard-thai
+Architecture: any
+Depends: ubuntu-keyboard (= ${binary:Version}),
+        ${misc:Depends},
+        ${shlibs:Depends},
+Description: Ubuntu on-screen keyboard data files - Thai
+ Data files for the Ubuntu virtual keyboard - Thai
+
 Package: ubuntu-keyboard-turkish
 Architecture: any
 Depends: ubuntu-keyboard (= ${binary:Version}),

--- a/debian/ubuntu-keyboard-thai.install
+++ b/debian/ubuntu-keyboard-thai.install
@@ -1,0 +1,1 @@
+usr/share/maliit/plugins/com/ubuntu/lib/th/

--- a/plugins/plugins.pro
+++ b/plugins/plugins.pro
@@ -36,6 +36,7 @@ SUBDIRS = \
     pt \
     ro \
     ru \
+    th \
     tr \
     sl \
     sr \

--- a/plugins/th/qml/Keyboard_th.qml
+++ b/plugins/th/qml/Keyboard_th.qml
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2013 Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+import keys 1.0
+import "keys/"
+
+KeyPad {
+    anchors.fill: parent
+
+    content: c1
+    symbols: "languages/Keyboard_symbols.qml"
+
+    Column {
+        id: c1
+        anchors.fill: parent
+        spacing: 0
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            ThCharKey { label: "ๅ"; shifted: "+"; extended: ["1", "๑"]; extendedShifted: ["1", "๑"]; leftSide: true; }
+            ThCharKey { label: "/"; shifted: "๑"; extended: ["2", "๒"]; extendedShifted: ["2", "๒"] }
+            ThCharKey { label: "-"; shifted: "๒"; extended: ["3", "๓"]; extendedShifted: ["3", "๓"] }
+            ThCharKey { label: "ภ"; shifted: "๓"; extended: ["4", "๔"]; extendedShifted: ["4", "๔"] }
+            ThCharKey { label: "ถ"; shifted: "๔"; extended: ["5", "๕"]; extendedShifted: ["5", "๕"] }
+            ThCharKey { label: " ุ"; shifted: " ู"; }
+            ThCharKey { label: " ึ"; shifted: "฿"; }
+            ThCharKey { label: "ค"; shifted: "๕"; extended: ["6", "๖"]; extendedShifted: ["6", "๖"] }
+            ThCharKey { label: "ต"; shifted: "๖"; extended: ["7", "๗"]; extendedShifted: ["7", "๗"] }
+            ThCharKey { label: "จ"; shifted: "๗"; extended: ["8", "๘"]; extendedShifted: ["8", "๘"] }
+            ThCharKey { label: "ข"; shifted: "๘"; extended: ["9", "๙"]; extendedShifted: ["9", "๙"] }
+            ThCharKey { label: "ช"; shifted: "๙"; extended: ["0", "๐"]; extendedShifted: ["0", "๐"]; rightSide: true }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            ThCharKey { label: "ๆ"; shifted: "๐"; leftSide: true; }
+            ThCharKey { label: "ไ"; shifted: "\""; }
+            ThCharKey { label: "ำ"; shifted: "ฎ"; }
+            ThCharKey { label: "พ"; shifted: "ฑ"; }
+            ThCharKey { label: "ะ"; shifted: "ธ"; }
+            ThCharKey { label: " ั"; shifted: " ํ"; }
+            ThCharKey { label: " ี"; shifted: " ๊"; }
+            ThCharKey { label: "ร"; shifted: "ณ"; }
+            ThCharKey { label: "น"; shifted: "ฯ"; }
+            ThCharKey { label: "ย"; shifted: "ญ"; }
+            ThCharKey { label: "บ"; shifted: "ฐ"; }
+            ThCharKey { label: "ล"; shifted: ","; rightSide: true; }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            ThCharKey { label: "ฟ"; shifted: "ฤ"; leftSide: true; }
+            ThCharKey { label: "ห"; shifted: "ฆ"; }
+            ThCharKey { label: "ก"; shifted: "ฏ"; }
+            ThCharKey { label: "ด"; shifted: "โ"; }
+            ThCharKey { label: "เ"; shifted: "ฌ"; }
+            ThCharKey { label: " ้"; shifted: " ็"; }
+            ThCharKey { label: " ่"; shifted: " ๋"; }
+            ThCharKey { label: "า"; shifted: "ษ"; }
+            ThCharKey { label: "ส"; shifted: "ศ"; }
+            ThCharKey { label: "ว"; shifted: "ซ"; }
+            ThCharKey { label: "ง"; shifted: "."; }
+            ThCharKey { label: "ฃ"; shifted: "ฅ"; rightSide: true; }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            // Shift and Backspace are as wide as other keys, because there're more keys.
+            ShiftKey { padding: 0 }
+            ThCharKey { label: "ผ"; shifted: "("; }
+            ThCharKey { label: "ป"; shifted: ")"; }
+            ThCharKey { label: "แ"; shifted: "ฉ"; }
+            ThCharKey { label: "อ"; shifted: "ฮ"; }
+            ThCharKey { label: " ิ"; shifted: " ฺ"; }
+            ThCharKey { label: " ื"; shifted: " ์"; }
+            ThCharKey { label: "ท"; shifted: "?"; }
+            ThCharKey { label: "ม"; shifted: "ฒ"; }
+            ThCharKey { label: "ใ"; shifted: "ฬ"; }
+            ThCharKey { label: "ฝ"; shifted: "ฦ"; }
+            BackspaceKey { padding: 0 }
+        }
+
+        Item {
+            anchors.left: parent.left
+            anchors.right: parent.right
+
+            height: panel.keyHeight + units.gu(UI.row_margin);
+
+            SymbolShiftKey { id: symShiftKey;                            anchors.left: parent.left; height: parent.height; }
+            LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
+            CharKey        { id: commaKey;    label: ","; shifted: ","; extended: ["'", "\"", ";", ":", "@", "&", "(", ")"]; extendedShifted: ["'", "\"", ";", ":", "@", "&", "(", ")"]; anchors.left: languageMenuButton.right; height: parent.height; }
+            SpaceKey       { id: spaceKey;                               anchors.left: commaKey.right; anchors.right: dotKey.left; noMagnifier: true; height: parent.height; }
+            CharKey        { id: dotKey;       label: "."; shifted: "."; extended: ["?", "-", "_", "!", "+", "%","#","/"]; extendedShifted: ["?", "-", "_", "!", "+", "%","#","/"]; anchors.right: enterKey.left; height: parent.height; }
+            ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
+        }
+    } // column
+}

--- a/plugins/th/qml/Keyboard_th_email.qml
+++ b/plugins/th/qml/Keyboard_th_email.qml
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2013 Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+import keys 1.0
+import "keys/"
+
+KeyPad {
+    anchors.fill: parent
+
+    content: c1
+    symbols: "languages/Keyboard_symbols.qml"
+
+    Column {
+        id: c1
+        anchors.fill: parent
+        spacing: 0
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            ThCharKey { label: "ๅ"; shifted: "+"; extended: ["1", "๑"]; extendedShifted: ["1", "๑"]; leftSide: true; }
+            ThCharKey { label: "/"; shifted: "๑"; extended: ["2", "๒"]; extendedShifted: ["2", "๒"] }
+            ThCharKey { label: "-"; shifted: "๒"; extended: ["3", "๓"]; extendedShifted: ["3", "๓"] }
+            ThCharKey { label: "ภ"; shifted: "๓"; extended: ["4", "๔"]; extendedShifted: ["4", "๔"] }
+            ThCharKey { label: "ถ"; shifted: "๔"; extended: ["5", "๕"]; extendedShifted: ["5", "๕"] }
+            ThCharKey { label: " ุ"; shifted: " ู"; }
+            ThCharKey { label: " ึ"; shifted: "฿"; }
+            ThCharKey { label: "ค"; shifted: "๕"; extended: ["6", "๖"]; extendedShifted: ["6", "๖"] }
+            ThCharKey { label: "ต"; shifted: "๖"; extended: ["7", "๗"]; extendedShifted: ["7", "๗"] }
+            ThCharKey { label: "จ"; shifted: "๗"; extended: ["8", "๘"]; extendedShifted: ["8", "๘"] }
+            ThCharKey { label: "ข"; shifted: "๘"; extended: ["9", "๙"]; extendedShifted: ["9", "๙"] }
+            ThCharKey { label: "ช"; shifted: "๙"; extended: ["0", "๐"]; extendedShifted: ["0", "๐"]; rightSide: true }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            ThCharKey { label: "ๆ"; shifted: "๐"; leftSide: true; }
+            ThCharKey { label: "ไ"; shifted: "\""; }
+            ThCharKey { label: "ำ"; shifted: "ฎ"; }
+            ThCharKey { label: "พ"; shifted: "ฑ"; }
+            ThCharKey { label: "ะ"; shifted: "ธ"; }
+            ThCharKey { label: " ั"; shifted: " ํ"; }
+            ThCharKey { label: " ี"; shifted: " ๊"; }
+            ThCharKey { label: "ร"; shifted: "ณ"; }
+            ThCharKey { label: "น"; shifted: "ฯ"; }
+            ThCharKey { label: "ย"; shifted: "ญ"; }
+            ThCharKey { label: "บ"; shifted: "ฐ"; }
+            ThCharKey { label: "ล"; shifted: ","; rightSide: true; }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            ThCharKey { label: "ฟ"; shifted: "ฤ"; leftSide: true; }
+            ThCharKey { label: "ห"; shifted: "ฆ"; }
+            ThCharKey { label: "ก"; shifted: "ฏ"; }
+            ThCharKey { label: "ด"; shifted: "โ"; }
+            ThCharKey { label: "เ"; shifted: "ฌ"; }
+            ThCharKey { label: " ้"; shifted: " ็"; }
+            ThCharKey { label: " ่"; shifted: " ๋"; }
+            ThCharKey { label: "า"; shifted: "ษ"; }
+            ThCharKey { label: "ส"; shifted: "ศ"; }
+            ThCharKey { label: "ว"; shifted: "ซ"; }
+            ThCharKey { label: "ง"; shifted: "."; }
+            ThCharKey { label: "ฃ"; shifted: "ฅ"; rightSide: true; }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            // Shift and Backspace are as wide as other keys, because there're more keys.
+            ShiftKey { padding: 0 }
+            ThCharKey { label: "ผ"; shifted: "("; }
+            ThCharKey { label: "ป"; shifted: ")"; }
+            ThCharKey { label: "แ"; shifted: "ฉ"; }
+            ThCharKey { label: "อ"; shifted: "ฮ"; }
+            ThCharKey { label: " ิ"; shifted: " ฺ"; }
+            ThCharKey { label: " ื"; shifted: " ์"; }
+            ThCharKey { label: "ท"; shifted: "?"; }
+            ThCharKey { label: "ม"; shifted: "ฒ"; }
+            ThCharKey { label: "ใ"; shifted: "ฬ"; }
+            ThCharKey { label: "ฝ"; shifted: "ฦ"; }
+            BackspaceKey { padding: 0 }
+        }
+
+        Item {
+            anchors.left: parent.left
+            anchors.right: parent.right
+
+            height: panel.keyHeight + units.gu(UI.row_margin);
+            SymbolShiftKey { id: symShiftKey;                            anchors.left: parent.left; height: parent.height; }
+            LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
+            CharKey        { id: atKey;    label: "@"; shifted: "@";     anchors.left: languageMenuButton.right; height: parent.height; }
+            SpaceKey       { id: spaceKey;                               anchors.left: atKey.right; anchors.right: urlKey.left; noMagnifier: true; height: parent.height; }
+            UrlKey         { id: urlKey; label: ".co.th"; extended: [".com", ".th", ".co.th",".ac.th",".go.th",".mi.th",".or.th",".net.th",".in.th", ".ไทย"]; anchors.right: dotKey.left; height: parent.height; }
+            CharKey        { id: dotKey;      label: "."; shifted: ".";  extended: ["?", "-", "_", "!", "+", "%","#","/"]; extendedShifted: ["?", "-", "_", "!", "+", "%","#","/"]; anchors.right: enterKey.left; height: parent.height; }
+            ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
+        }
+    } // column
+}

--- a/plugins/th/qml/Keyboard_th_url.qml
+++ b/plugins/th/qml/Keyboard_th_url.qml
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2013 Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+import keys 1.0
+import "keys/"
+
+KeyPad {
+    anchors.fill: parent
+
+    content: c1
+    symbols: "languages/Keyboard_symbols.qml"
+
+    Column {
+        id: c1
+        anchors.fill: parent
+        spacing: 0
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            ThCharKey { label: "ๅ"; shifted: "+"; extended: ["1", "๑"]; extendedShifted: ["1", "๑"]; leftSide: true; }
+            ThCharKey { label: "/"; shifted: "๑"; extended: ["2", "๒"]; extendedShifted: ["2", "๒"] }
+            ThCharKey { label: "-"; shifted: "๒"; extended: ["3", "๓"]; extendedShifted: ["3", "๓"] }
+            ThCharKey { label: "ภ"; shifted: "๓"; extended: ["4", "๔"]; extendedShifted: ["4", "๔"] }
+            ThCharKey { label: "ถ"; shifted: "๔"; extended: ["5", "๕"]; extendedShifted: ["5", "๕"] }
+            ThCharKey { label: " ุ"; shifted: " ู"; }
+            ThCharKey { label: " ึ"; shifted: "฿"; }
+            ThCharKey { label: "ค"; shifted: "๕"; extended: ["6", "๖"]; extendedShifted: ["6", "๖"] }
+            ThCharKey { label: "ต"; shifted: "๖"; extended: ["7", "๗"]; extendedShifted: ["7", "๗"] }
+            ThCharKey { label: "จ"; shifted: "๗"; extended: ["8", "๘"]; extendedShifted: ["8", "๘"] }
+            ThCharKey { label: "ข"; shifted: "๘"; extended: ["9", "๙"]; extendedShifted: ["9", "๙"] }
+            ThCharKey { label: "ช"; shifted: "๙"; extended: ["0", "๐"]; extendedShifted: ["0", "๐"]; rightSide: true }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            ThCharKey { label: "ๆ"; shifted: "๐"; leftSide: true; }
+            ThCharKey { label: "ไ"; shifted: "\""; }
+            ThCharKey { label: "ำ"; shifted: "ฎ"; }
+            ThCharKey { label: "พ"; shifted: "ฑ"; }
+            ThCharKey { label: "ะ"; shifted: "ธ"; }
+            ThCharKey { label: " ั"; shifted: " ํ"; }
+            ThCharKey { label: " ี"; shifted: " ๊"; }
+            ThCharKey { label: "ร"; shifted: "ณ"; }
+            ThCharKey { label: "น"; shifted: "ฯ"; }
+            ThCharKey { label: "ย"; shifted: "ญ"; }
+            ThCharKey { label: "บ"; shifted: "ฐ"; }
+            ThCharKey { label: "ล"; shifted: ","; rightSide: true; }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            ThCharKey { label: "ฟ"; shifted: "ฤ"; leftSide: true; }
+            ThCharKey { label: "ห"; shifted: "ฆ"; }
+            ThCharKey { label: "ก"; shifted: "ฏ"; }
+            ThCharKey { label: "ด"; shifted: "โ"; }
+            ThCharKey { label: "เ"; shifted: "ฌ"; }
+            ThCharKey { label: " ้"; shifted: " ็"; }
+            ThCharKey { label: " ่"; shifted: " ๋"; }
+            ThCharKey { label: "า"; shifted: "ษ"; }
+            ThCharKey { label: "ส"; shifted: "ศ"; }
+            ThCharKey { label: "ว"; shifted: "ซ"; }
+            ThCharKey { label: "ง"; shifted: "."; }
+            ThCharKey { label: "ฃ"; shifted: "ฅ"; rightSide: true; }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            // Shift and Backspace are as wide as other keys, because there're more keys.
+            ShiftKey { padding: 0 }
+            ThCharKey { label: "ผ"; shifted: "("; }
+            ThCharKey { label: "ป"; shifted: ")"; }
+            ThCharKey { label: "แ"; shifted: "ฉ"; }
+            ThCharKey { label: "อ"; shifted: "ฮ"; }
+            ThCharKey { label: " ิ"; shifted: " ฺ"; }
+            ThCharKey { label: " ื"; shifted: " ์"; }
+            ThCharKey { label: "ท"; shifted: "?"; }
+            ThCharKey { label: "ม"; shifted: "ฒ"; }
+            ThCharKey { label: "ใ"; shifted: "ฬ"; }
+            ThCharKey { label: "ฝ"; shifted: "ฦ"; }
+            BackspaceKey { padding: 0 }
+        }
+
+        Item {
+            anchors.left: parent.left
+            anchors.right: parent.right
+
+            height: panel.keyHeight + units.gu(UI.row_margin);
+            SymbolShiftKey { id: symShiftKey;                            anchors.left: parent.left; height: parent.height; }
+            LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
+            CharKey        { id: slashKey; label: "/"; shifted: "/";     anchors.left: languageMenuButton.right; height: parent.height; }
+            UrlKey         { id: urlKey; label: ".co.th"; extended: [".com", ".th", ".co.th",".ac.th",".go.th",".mi.th",".or.th",".net.th",".in.th", ".ไทย"]; anchors.right: dotKey.left; height: parent.height; }
+            CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?", "-", "_", "!", "+", "%","#","/"]; extendedShifted: ["?", "-", "_", "!", "+", "%","#","/"]; anchors.right: enterKey.left; height: parent.height; }
+            ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
+        }
+    } // column
+}

--- a/plugins/th/qml/Keyboard_th_url_search.qml
+++ b/plugins/th/qml/Keyboard_th_url_search.qml
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2013 Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+import keys 1.0
+import "keys/"
+
+KeyPad {
+    anchors.fill: parent
+
+    content: c1
+    symbols: "languages/Keyboard_symbols.qml"
+
+    Column {
+        id: c1
+        anchors.fill: parent
+        spacing: 0
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            ThCharKey { label: "ๅ"; shifted: "+"; extended: ["1", "๑"]; extendedShifted: ["1", "๑"]; leftSide: true; }
+            ThCharKey { label: "/"; shifted: "๑"; extended: ["2", "๒"]; extendedShifted: ["2", "๒"] }
+            ThCharKey { label: "-"; shifted: "๒"; extended: ["3", "๓"]; extendedShifted: ["3", "๓"] }
+            ThCharKey { label: "ภ"; shifted: "๓"; extended: ["4", "๔"]; extendedShifted: ["4", "๔"] }
+            ThCharKey { label: "ถ"; shifted: "๔"; extended: ["5", "๕"]; extendedShifted: ["5", "๕"] }
+            ThCharKey { label: " ุ"; shifted: " ู"; }
+            ThCharKey { label: " ึ"; shifted: "฿"; }
+            ThCharKey { label: "ค"; shifted: "๕"; extended: ["6", "๖"]; extendedShifted: ["6", "๖"] }
+            ThCharKey { label: "ต"; shifted: "๖"; extended: ["7", "๗"]; extendedShifted: ["7", "๗"] }
+            ThCharKey { label: "จ"; shifted: "๗"; extended: ["8", "๘"]; extendedShifted: ["8", "๘"] }
+            ThCharKey { label: "ข"; shifted: "๘"; extended: ["9", "๙"]; extendedShifted: ["9", "๙"] }
+            ThCharKey { label: "ช"; shifted: "๙"; extended: ["0", "๐"]; extendedShifted: ["0", "๐"]; rightSide: true }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            ThCharKey { label: "ๆ"; shifted: "๐"; leftSide: true; }
+            ThCharKey { label: "ไ"; shifted: "\""; }
+            ThCharKey { label: "ำ"; shifted: "ฎ"; }
+            ThCharKey { label: "พ"; shifted: "ฑ"; }
+            ThCharKey { label: "ะ"; shifted: "ธ"; }
+            ThCharKey { label: " ั"; shifted: " ํ"; }
+            ThCharKey { label: " ี"; shifted: " ๊"; }
+            ThCharKey { label: "ร"; shifted: "ณ"; }
+            ThCharKey { label: "น"; shifted: "ฯ"; }
+            ThCharKey { label: "ย"; shifted: "ญ"; }
+            ThCharKey { label: "บ"; shifted: "ฐ"; }
+            ThCharKey { label: "ล"; shifted: ","; rightSide: true; }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            ThCharKey { label: "ฟ"; shifted: "ฤ"; leftSide: true; }
+            ThCharKey { label: "ห"; shifted: "ฆ"; }
+            ThCharKey { label: "ก"; shifted: "ฏ"; }
+            ThCharKey { label: "ด"; shifted: "โ"; }
+            ThCharKey { label: "เ"; shifted: "ฌ"; }
+            ThCharKey { label: " ้"; shifted: " ็"; }
+            ThCharKey { label: " ่"; shifted: " ๋"; }
+            ThCharKey { label: "า"; shifted: "ษ"; }
+            ThCharKey { label: "ส"; shifted: "ศ"; }
+            ThCharKey { label: "ว"; shifted: "ซ"; }
+            ThCharKey { label: "ง"; shifted: "."; }
+            ThCharKey { label: "ฃ"; shifted: "ฅ"; rightSide: true; }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            spacing: 0
+
+            // Shift and Backspace are as wide as other keys, because there're more keys.
+            ShiftKey { padding: 0 }
+            ThCharKey { label: "ผ"; shifted: "("; }
+            ThCharKey { label: "ป"; shifted: ")"; }
+            ThCharKey { label: "แ"; shifted: "ฉ"; }
+            ThCharKey { label: "อ"; shifted: "ฮ"; }
+            ThCharKey { label: " ิ"; shifted: " ฺ"; }
+            ThCharKey { label: " ื"; shifted: " ์"; }
+            ThCharKey { label: "ท"; shifted: "?"; }
+            ThCharKey { label: "ม"; shifted: "ฒ"; }
+            ThCharKey { label: "ใ"; shifted: "ฬ"; }
+            ThCharKey { label: "ฝ"; shifted: "ฦ"; }
+            BackspaceKey { padding: 0 }
+        }
+
+        Item {
+            anchors.left: parent.left
+            anchors.right: parent.right
+
+            height: panel.keyHeight + units.gu(UI.row_margin);
+            SymbolShiftKey { id: symShiftKey;                            anchors.left: parent.left; height: parent.height; }
+            LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
+            CharKey        { id: slashKey; label: "/"; shifted: "/";     anchors.left: languageMenuButton.right; height: parent.height; }
+            SpaceKey       { id: spaceKey;                               anchors.left: slashKey.right; anchors.right: urlKey.left; noMagnifier: true; height: parent.height; }
+            UrlKey         { id: urlKey; label: ".co.th"; extended: [".com", ".th", ".co.th",".ac.th",".go.th",".mi.th",".or.th",".net.th",".in.th", ".ไทย"]; anchors.right: dotKey.left; height: parent.height; }
+            CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?", "-", "_", "!", "+", "%","#","/"]; extendedShifted: ["?", "-", "_", "!", "+", "%","#","/"]; anchors.right: enterKey.left; height: parent.height; }
+            ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
+        }
+    } // column
+}

--- a/plugins/th/qml/keys/ThCharKey.qml
+++ b/plugins/th/qml/keys/ThCharKey.qml
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 Canonical Ltd.
+ * Copyright (C) 2020 UBports Foundation.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import keys 1.0
+
+CharKey {
+    // Some Thai vowel is put above or below character, thus requiring an
+    // extra character for the label to show properly. Modifies the
+    // valueToSubmit property to strip such extra character.
+
+    readonly property string labelStripped: label.slice(-1)
+    readonly property string shiftedStripped: shifted.slice(-1)
+
+    valueToSubmit: (panel.activeKeypadState === "NORMAL")
+                        ? labelStripped
+                        : shiftedStripped;
+}

--- a/plugins/th/qml/qml.pro
+++ b/plugins/th/qml/qml.pro
@@ -1,0 +1,23 @@
+TOP_BUILDDIR = $$OUT_PWD/../../..
+TOP_SRCDIR = $$PWD/../../..
+
+include($${TOP_SRCDIR}/config.pri)
+
+TARGET = dummy
+TEMPLATE = lib
+
+lang_th.path = "$${UBUNTU_KEYBOARD_LIB_DIR}/th/"
+lang_th.files = *.qml *.js
+
+lang_th_keys.path = "$${UBUNTU_KEYBOARD_LIB_DIR}/th/keys"
+lang_th_keys.files = keys/*.qml keys/*.js
+
+INSTALLS += lang_th lang_th_keys
+
+# for QtCreator
+OTHER_FILES += \
+    Keyboard_th.qml \
+    Keyboard_th_email.qml \
+    Keyboard_th_url.qml \
+    Keyboard_th_url_search.qml
+

--- a/plugins/th/src/src.pro
+++ b/plugins/th/src/src.pro
@@ -1,0 +1,31 @@
+TOP_BUILDDIR = $$OUT_PWD/../../..
+TOP_SRCDIR = $$PWD/../../..
+
+include($${TOP_SRCDIR}/config.pri)
+
+TEMPLATE        = lib
+CONFIG         += plugin
+QT             += widgets
+INCLUDEPATH    += \
+    $${TOP_SRCDIR}/src/ \
+    $${TOP_SRCDIR}/src/lib/logic
+
+HEADERS         = \
+                  thaiplugin.h \
+                  thailanguagefeatures.h \
+                  $${TOP_SRCDIR}/src/lib/logic/abstractlanguageplugin.h
+
+SOURCES         = \
+                  thaiplugin.cpp \
+                  thailanguagefeatures.cpp \
+                  $${TOP_SRCDIR}/src/lib/logic/abstractlanguageplugin.cpp
+
+TARGET          = $$qtLibraryTarget(thplugin)
+
+PLUGIN_INSTALL_PATH = $${UBUNTU_KEYBOARD_LIB_DIR}/th/
+
+target.path = $$PLUGIN_INSTALL_PATH
+INSTALLS += target
+
+OTHER_FILES += \
+    thaiplugin.json

--- a/plugins/th/src/thailanguagefeatures.cpp
+++ b/plugins/th/src/thailanguagefeatures.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014 Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "thailanguagefeatures.h"
+
+ThaiLanguageFeatures::ThaiLanguageFeatures(QObject *parent) :
+    QObject(parent)
+{
+}
+
+ThaiLanguageFeatures::~ThaiLanguageFeatures()
+{
+}
+
+bool ThaiLanguageFeatures::alwaysShowSuggestions() const
+{
+    return false;
+}
+
+bool ThaiLanguageFeatures::autoCapsAvailable() const
+{
+    return false;
+}
+
+bool ThaiLanguageFeatures::activateAutoCaps(const QString &preedit) const
+{
+    Q_UNUSED(preedit)
+    return false;
+}
+
+QString ThaiLanguageFeatures::appendixForReplacedPreedit(const QString &preedit) const
+{
+    Q_UNUSED(preedit)
+    return QString("");
+}
+
+bool ThaiLanguageFeatures::isSeparator(const QString &text) const
+{
+    static const QString separators = QString::fromUtf8("。、,!?:;.\r\n");
+
+    if (text.isEmpty()) {
+        return false;
+    }
+
+    if (separators.contains(text.right(1))) {
+        return true;
+    }
+
+    return false;
+}
+
+bool ThaiLanguageFeatures::isSymbol(const QString &text) const
+{
+    static const QString symbols = QString::fromUtf8("*#+=()@~/\\€£$¥₹%<>[]`^|_§{}¡¿«»\"“”„&0123456789");
+
+    if (text.isEmpty()) {
+        return false;
+    }
+
+    if (symbols.contains(text.right(1))) {
+        return true;
+    }
+
+    return false;
+}

--- a/plugins/th/src/thailanguagefeatures.h
+++ b/plugins/th/src/thailanguagefeatures.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef THAILANGUAGEFEATURES_H
+#define THAILANGUAGEFEATURES_H
+
+#include "abstractlanguagefeatures.h"
+#include <QObject>
+
+class ThaiLanguageFeatures : public QObject, public AbstractLanguageFeatures
+{
+    Q_OBJECT
+public:
+    explicit ThaiLanguageFeatures(QObject *parent = 0);
+    virtual ~ThaiLanguageFeatures();
+
+    virtual bool alwaysShowSuggestions() const;
+    virtual bool autoCapsAvailable() const;
+    virtual bool activateAutoCaps(const QString &preedit) const;
+    virtual QString appendixForReplacedPreedit(const QString &preedit) const;
+    virtual bool isSeparator(const QString &text) const;
+    virtual bool isSymbol(const QString &text) const;
+};
+
+#endif // THAILANGUAGEFEATURES_H

--- a/plugins/th/src/thaiplugin.cpp
+++ b/plugins/th/src/thaiplugin.cpp
@@ -1,0 +1,18 @@
+#include "thaiplugin.h"
+#include "thailanguagefeatures.h"
+
+
+ThaiPlugin::ThaiPlugin(QObject *parent) :
+    AbstractLanguagePlugin(parent)
+  , m_thaiLanguageFeatures(new ThaiLanguageFeatures(/* parent */ this))
+{
+}
+
+ThaiPlugin::~ThaiPlugin()
+{
+}
+
+AbstractLanguageFeatures* ThaiPlugin::languageFeature()
+{
+    return m_thaiLanguageFeatures;
+}

--- a/plugins/th/src/thaiplugin.h
+++ b/plugins/th/src/thaiplugin.h
@@ -1,0 +1,26 @@
+#ifndef THAIPLUGIN_H
+#define THAIPLUGIN_H
+
+#include <QObject>
+#include "languageplugininterface.h"
+#include "abstractlanguageplugin.h"
+
+class ThaiLanguageFeatures;
+
+class ThaiPlugin : public AbstractLanguagePlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "com.canonical.UbuntuKeyboard.LanguagePluginInterface" FILE "thaiplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
+
+public:
+    explicit ThaiPlugin(QObject *parent = 0);
+    virtual ~ThaiPlugin();
+    
+    virtual AbstractLanguageFeatures* languageFeature();
+
+private:
+    ThaiLanguageFeatures* m_thaiLanguageFeatures;
+};
+
+#endif // THAIPLUGIN_H

--- a/plugins/th/src/thaiplugin.json
+++ b/plugins/th/src/thaiplugin.json
@@ -1,0 +1,7 @@
+{
+    "IID": "com.canonical.UbuntuKeyboard.LanguagePluginInterface",
+    "MetaData": {
+    },
+    "className": "ThaiPlugin",
+    "debug": true
+}

--- a/plugins/th/th.pro
+++ b/plugins/th/th.pro
@@ -1,0 +1,9 @@
+CONFIG += ordered
+TEMPLATE = subdirs
+SUBDIRS = \
+    src \
+    qml
+
+QMAKE_EXTRA_TARGETS += check
+check.target = check
+check.CONFIG = recursive

--- a/qml/keys/languages.js
+++ b/qml/keys/languages.js
@@ -53,6 +53,7 @@ function languageIdToName(languageId)
     if (languageId == "sl")         return i18n.tr("Slovenian");
     if (languageId == "sr")         return i18n.tr("Serbian");
     if (languageId == "sv")         return i18n.tr("Swedish");
+    if (languageId == "th")         return i18n.tr("Thai");
     if (languageId == "tr")         return i18n.tr("Turkish");
     if (languageId == "uk")         return i18n.tr("Ukrainian");
     if (languageId == "zh-hans")         return i18n.tr("Chinese\n(Pinyin)");


### PR DESCRIPTION
This commit adds keyboard layouts in Thai language, along with an empty
language plugin and language features. This language differs enough from
most western languages that it cannot use the common westernsupport
base.

It's easy to add keyboard layouts. It's a different story to add a
decent word prediction. I would need to find an example text for it to
create the n-gram database and would have to write a language features
more or less from scratch. Besides, the text2ngram utility seems to
assume that words are separated by whitespaces, which isn't the case
for Thai. So, let's get keyboard layouts out; at least you will not
encounter bad autocorrection (!).

Fixes #122.