### PR TITLE
Fixed polish keyboard layout

### DIFF
--- a/plugins/pl/qml/Keyboard_pl.qml
+++ b/plugins/pl/qml/Keyboard_pl.qml
@@ -41,8 +41,7 @@ KeyPad {
             CharKey { label: "u"; shifted: "U"; extended: ["7"]; extendedShifted: ["7"] }
             CharKey { label: "i"; shifted: "I"; extended: ["8"]; extendedShifted: ["8"] }
             CharKey { label: "o"; shifted: "O"; extended: ["9", "ó"]; extendedShifted: ["9", "Ó"] }
-            CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"] }
-            CharKey { label: "ż"; shifted: "Ż"; rightSide: true; }
+            CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"]; rightSide: true; }
         }
 
         Row {
@@ -57,9 +56,7 @@ KeyPad {
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; extended: ["ł"]; extendedShifted: ["Ł"] }
-            CharKey { label: "ł"; shifted: "Ł"; }
-            CharKey { label: "ą"; shifted: "Ą"; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; extended: ["ł"]; extendedShifted: ["Ł"]; rightSide: true; }
         }
 
         Row {
@@ -74,7 +71,6 @@ KeyPad {
             CharKey { label: "b"; shifted: "B"; }
             CharKey { label: "n"; shifted: "N"; extended: ["ń"]; extendedShifted: ["Ń"] }
             CharKey { label: "m"; shifted: "M"; }
-            CharKey { label: "ę"; shifted: "Ę"; }
             BackspaceKey {}
         }
 

--- a/plugins/pl/qml/Keyboard_pl_email.qml
+++ b/plugins/pl/qml/Keyboard_pl_email.qml
@@ -41,8 +41,7 @@ KeyPad {
             CharKey { label: "u"; shifted: "U"; extended: ["7"]; extendedShifted: ["7"] }
             CharKey { label: "i"; shifted: "I"; extended: ["8"]; extendedShifted: ["8"] }
             CharKey { label: "o"; shifted: "O"; extended: ["9", "ó"]; extendedShifted: ["9", "Ó"] }
-            CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"] }
-            CharKey { label: "ż"; shifted: "Ż"; rightSide: true; }
+            CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"]; rightSide: true; }
         }
 
         Row {
@@ -57,9 +56,7 @@ KeyPad {
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; extended: ["ł"]; extendedShifted: ["Ł"] }
-            CharKey { label: "ł"; shifted: "Ł"; }
-            CharKey { label: "ą"; shifted: "Ą"; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; extended: ["ł"]; extendedShifted: ["Ł"]; rightSide: true; }
         }
 
         Row {
@@ -74,7 +71,6 @@ KeyPad {
             CharKey { label: "b"; shifted: "B"; }
             CharKey { label: "n"; shifted: "N"; extended: ["ń"]; extendedShifted: ["Ń"] }
             CharKey { label: "m"; shifted: "M"; }
-            CharKey { label: "ę"; shifted: "Ę"; }
             BackspaceKey {}
         }
 

--- a/plugins/pl/qml/Keyboard_pl_url.qml
+++ b/plugins/pl/qml/Keyboard_pl_url.qml
@@ -41,8 +41,7 @@ KeyPad {
             CharKey { label: "u"; shifted: "U"; extended: ["7"]; extendedShifted: ["7"] }
             CharKey { label: "i"; shifted: "I"; extended: ["8"]; extendedShifted: ["8"] }
             CharKey { label: "o"; shifted: "O"; extended: ["9", "ó"]; extendedShifted: ["9", "Ó"] }
-            CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"]; }
-            CharKey { label: "ż"; shifted: "Ż"; rightSide: true; }
+            CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"]; rightSide: true; }
         }
 
         Row {
@@ -57,9 +56,7 @@ KeyPad {
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; extended: ["ł"]; extendedShifted: ["Ł"] }
-            CharKey { label: "ł"; shifted: "Ł"; }
-            CharKey { label: "ą"; shifted: "Ą"; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; extended: ["ł"]; extendedShifted: ["Ł"]; rightSide: true; }
         }
 
         Row {
@@ -74,7 +71,6 @@ KeyPad {
             CharKey { label: "b"; shifted: "B"; }
             CharKey { label: "n"; shifted: "N"; extended: ["ń"]; extendedShifted: ["Ń"] }
             CharKey { label: "m"; shifted: "M"; }
-            CharKey { label: "ę"; shifted: "Ę"; }
             BackspaceKey {}
         }
 

--- a/plugins/pl/qml/Keyboard_pl_url_search.qml
+++ b/plugins/pl/qml/Keyboard_pl_url_search.qml
@@ -41,8 +41,7 @@ KeyPad {
             CharKey { label: "u"; shifted: "U"; extended: ["7"]; extendedShifted: ["7"] }
             CharKey { label: "i"; shifted: "I"; extended: ["8"]; extendedShifted: ["8"] }
             CharKey { label: "o"; shifted: "O"; extended: ["9", "ó"]; extendedShifted: ["9", "Ó"] }
-            CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"] }
-            CharKey { label: "ż"; shifted: "Ż"; rightSide: true; }
+            CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"]; rightSide: true; }
         }
 
         Row {
@@ -57,9 +56,7 @@ KeyPad {
             CharKey { label: "h"; shifted: "H"; }
             CharKey { label: "j"; shifted: "J"; }
             CharKey { label: "k"; shifted: "K"; }
-            CharKey { label: "l"; shifted: "L"; extended: ["ł"]; extendedShifted: ["Ł"] }
-            CharKey { label: "ł"; shifted: "Ł"; }
-            CharKey { label: "ą"; shifted: "Ą"; rightSide: true; }
+            CharKey { label: "l"; shifted: "L"; extended: ["ł"]; extendedShifted: ["Ł"]; rightSide: true; }
         }
 
         Row {
@@ -74,7 +71,6 @@ KeyPad {
             CharKey { label: "b"; shifted: "B"; }
             CharKey { label: "n"; shifted: "N"; extended: ["ń"]; extendedShifted: ["Ń"] }
             CharKey { label: "m"; shifted: "M"; }
-            CharKey { label: "ę"; shifted: "Ę"; }
             BackspaceKey {}
         }
 


### PR DESCRIPTION
I've removed letters Ż Ł Ą Ę that appeared on right side
# Old layout
![obraz](https://user-images.githubusercontent.com/20381330/86841718-92e6f300-c0a4-11ea-9298-7817ec5efee4.png)
Nobody of peoples who I know liked using this keyboard layout.

# New layout
![obraz](https://user-images.githubusercontent.com/20381330/86842619-bf4f3f00-c0a5-11ea-805d-22ce78087735.png)

The keyboard is fully usable, it contains all special characters that we have in our language, and use a more common way of typing them