### PR TITLE
Fixed #63

### DIFF
--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -79,6 +79,7 @@ Item {
         property int keypadHeight: height;
 
         visible: true
+        layer.enabled: true
 
         property bool wordribbon_visible: maliit_word_engine.enabled
         onWordribbon_visibleChanged: fullScreenItem.reportKeyboardVisibleRect();


### PR DESCRIPTION
This applies opacity to the whole keyboard instead of individually per child item