### PR TITLE
Remove max width of done button

### DIFF
--- a/qml/FloatingActions.qml
+++ b/qml/FloatingActions.qml
@@ -55,7 +55,6 @@ RowLayout {
         Layout.alignment: Qt.AlignHCenter
         Layout.fillWidth: true
         Layout.minimumWidth: units.gu(5)
-        Layout.maximumWidth: units.gu(20)
         Layout.preferredHeight: units.gu(5)
         keyFeedback: false
         action: Action {


### PR DESCRIPTION
This will fix the layout of the floating buttons when in landscape and wide screens.